### PR TITLE
Allow non-browser JS clients to connect

### DIFF
--- a/src/haxe/net/impl/WebSocketJs.hx
+++ b/src/haxe/net/impl/WebSocketJs.hx
@@ -33,9 +33,7 @@ class WebSocketJs extends WebSocket {
 			if (Std.is(m, String)) {
 				this.onmessageString(m);
 			} else if (Std.is(m, ArrayBuffer)) {
-				// haxe.io.Int8Array
-				// js.html.ArrayBuffer
-				trace('Unhandled websocket onmessage ' + m);
+				this.onmessageBytes(Bytes.ofData(cast (m,ArrayBuffer)));
 			} else if (Std.is(m, js.html.Blob)) {
 				var arrayBuffer:ArrayBuffer;
 				var fileReader = new js.html.FileReader();


### PR DESCRIPTION
Fixed the unhandled message type, this allows using this library with non-browser JS clients of Colyseus